### PR TITLE
Add new easier mappings for slurp and barf

### DIFF
--- a/.config/nvim/fnl/plugins/paredit.fnl
+++ b/.config/nvim/fnl/plugins/paredit.fnl
@@ -6,7 +6,10 @@
   :ft [:clojure :fennel]
   :config (fn []
             (let [paredit (require :nvim-paredit)]
-              (paredit.setup)))}
+              (paredit.setup {:keys {:<localleader>d [paredit.api.slurp_forwards "Slurp forwards"]
+                                    :<localleader>D [paredit.api.barf_forwards "Barf forwards"]
+                                    :<localleader>a [paredit.api.slurp_backwards "Slurp backwards"]
+                                    :<localleader>A [paredit.api.barf_backwards "Barf backwards"]}})))}
 
  {1 :julienvincent/nvim-paredit-fennel
   :dependencies [:julienvincent/nvim-paredit]

--- a/.config/nvim/lua/plugins/paredit.lua
+++ b/.config/nvim/lua/plugins/paredit.lua
@@ -4,7 +4,7 @@ local autoload = _local_1_["autoload"]
 local nvim = autoload("nvim")
 local function _2_()
   local paredit = require("nvim-paredit")
-  return paredit.setup()
+  return paredit.setup({keys = {["<localleader>d"] = {paredit.api.slurp_forwards, "Slurp forwards"}, ["<localleader>D"] = {paredit.api.barf_forwards, "Barf forwards"}, ["<localleader>a"] = {paredit.api.slurp_backwards, "Slurp backwards"}, ["<localleader>A"] = {paredit.api.barf_backwards, "Barf backwards"}}})
 end
 local function _3_()
   local paredit_fnl = require("nvim-paredit-fennel")

--- a/readme.md
+++ b/readme.md
@@ -96,6 +96,8 @@ All about nvim's lsp settings and keymaps.
 ### [.config/nvim/fnl/plugins/paredit.fnl](.config/nvim/fnl/plugins/paredit.fnl)
 Config for a bundle of plugins to have a modern "vim-sexp-mappings-for-regular-people" like experience for lisp languages like Clojure and Fennel.
 
+Adds simpler mappings for slurpage and barfage using `<localleader>a|A|d|D`, so that `<localleader>a` and `<localleader>d` move the current form closure backwards or forwards and `<localleader>A` and `<localleader>D` revert these same movements (in vim fashion).
+
 ### [.config/nvim/fnl/plugins/telescope.fnl](.config/nvim/fnl/plugins/telescope.fnl)
 Settings like ignore `node_modules` and everything in `.gitignore` to be listed in the file finder.
 Keymaps:


### PR DESCRIPTION
The default mappings for paredit `">)", "<)" and such` are not easy to use and also are not intuitive. This PR remaps them to `<localleader>a|A|d|D`, where `a` and `d` move the closure of current form backwards or forwards and `A` and `D` revert these same movements (in the spirit of vim).