### PR TITLE
fix: readme image position

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,4 @@
-<img src="docs/cajus-nvim.png" width="128" align="right">
-
-# cajus-nfnl
+# cajus-nfnl <img src="docs/cajus-nvim.png" width="128" align="right">
 A curvy and juicy neovim configuration following the "Keep it simple!" design principle, but using [nfnl](https://github.com/Olical/nfnl) instead of [aniseed](https://github.com/Olical/aniseed).
 
 Fork from [cajus-nvim](https://github.com/rafaeldelboni/cajus-nvim)


### PR DESCRIPTION
Just trying to find a better position for the cajus-nfnl image!

**Before**:
![image](https://github.com/rafaeldelboni/cajus-nfnl/assets/91899995/0ebd2318-9ebd-4639-aff0-e3e0889635de)

**After**:
![image](https://github.com/rafaeldelboni/cajus-nfnl/assets/91899995/71d9a05a-d0a9-4aee-b3ff-943387655062)

Now the image is aligned with title!

> [!NOTE]
> Thank you to provide this repository, I'm learning a lot about Fennel and how can I customize my settings using it!